### PR TITLE
Include template option for specifying custom output template file.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -40,6 +40,10 @@ var opts = require('nomnom')
     default: 'css',
     help: 'output format of the css. one of css, less, sass, scss or stylus'
   })
+  .option('template', {
+    abbr: 't',
+    help: 'output template file, overrides processor option'
+  })
   .option('retina', {
     abbr: 'r',
     flag: true,

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var defaults = {
   style: null,
   cssPath: '../images',
   processor: 'css',
+  template: null,
   orientation: 'vertical',
   retina: false,
   margin: 5

--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -113,7 +113,7 @@ module.exports = function (opt) {
       total_width: sprite.canvas.width,
       total_height: sprite.canvas.height
     });
-    return json2css(sprites, {'format': 'sprite', formatOpts: {'cssClass': opt.prefix, 'processor': opt.processor}});
+    return json2css(sprites, {'format': 'sprite', formatOpts: {'cssClass': opt.prefix, 'processor': opt.processor, 'template': opt.template}});
   }
 
   function createSprite (cb) {

--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -48,7 +48,10 @@ function cssTemplate (params) {
     }
   });
   // Render and return CSS
-  var css = mustache.render(tmpl[options.processor], tmplParams);
+  var tmplFile = options.template
+    ? fs.readFileSync(options.template, 'utf8')
+    : tmpl[options.processor];
+  var css = mustache.render(tmplFile, tmplParams);
   return css;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ Options:
    -c, --css-image-path   http path to images on the web server (relative to css path or absolute path)  [../images]
    -n, --name             name of sprite file  [sprite.png]
    -p, --processor        output format of the css. one of css, less, sass, scss or stylus  [css]
+   -t, --template         output template file, overrides processor option
    -r, --retina           generate both retina and standard sprites. src images have to be in retina resolution
    -s, --style            file to write css to, if ommited no css is written
    -w, --watch            continuously create sprite
@@ -64,6 +65,7 @@ sprite.create(options, cb);
 * **cssPath:** http path to images on the web server (relative to css path or absolute)  [../images]
 * **name:** name of the sprite file  [sprite.png]
 * **processor:** output format of the css. one of css, less, sass, scss or stylus  [css]
+* **template:** output template file, overrides processor option
 * **retina:** generate both retina and standard sprites. src images have to be in retina resolution
 * **style:** file to write css to, if omitted no css is written
 * **margin:** margin in px between tiles  [5]


### PR DESCRIPTION
This addition allows you to specify a custom mustache template file, useful when you want to use classes, variables and mixins (sass/less) that are named differently from those provided in the default templates.

I needed this because the default mixin names in the scss template conflicted with other mixins I was using elsewhere in my code.
