### PR TITLE
Added binary-tree layout orientation [fixes #13]

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -59,7 +59,7 @@ var opts = require('nomnom')
     help: 'margin in px between tiles'
   })
   .option('orientation', {
-    choices: ['vertical', 'horizontal'],
+    choices: ['vertical', 'horizontal', 'binary-tree'],
     default: 'vertical',
     help: 'orientation of the sprite image'
   })

--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -7,6 +7,7 @@ var path = require('path');
 var json2css = require('json2css');
 var File = require('vinyl');
 var imageinfo = require('imageinfo');
+var layout = require('layout');
 var replaceExtension = require('./replace-extension');
 var Image = Canvas.Image;
 
@@ -19,11 +20,13 @@ module.exports = function (opt) {
   var sprites = [];
   var ctxHeight = 0;
   var ctxWidth = 0;
+  var layer = layout('binary-tree');
 
   function queue (file, img) {
+    var spriteName = replaceExtension(file.relative, '').replace(/\/|\\|\ /g, '-');
     sprites.push({
       'img': img,
-      'name': replaceExtension(file.relative, '').replace(/\/|\\|\ /g, '-'),
+      'name': spriteName,
       'x': opt.orientation === 'vertical' ? opt.margin : ctxWidth + opt.margin,
       'y': opt.orientation === 'vertical' ? ctxHeight + opt.margin: opt.margin,
       'width': img.width,
@@ -31,7 +34,15 @@ module.exports = function (opt) {
       'image': path.join(opt.cssPath, opt.name)
     });
 
-    if (opt.orientation === 'vertical') {
+    // binary-tree
+    if (opt.orientation === 'binary-tree') {
+      layer.addItem({
+        height: img.height + 2 * opt.margin,
+        width: img.width + 2 * opt.margin,
+        meta: spriteName
+      });
+    }
+    else if (opt.orientation === 'vertical') {
       ctxHeight = ctxHeight + img.height + 2 * opt.margin;
       if (img.width + 2 * opt.margin > ctxWidth) {
         ctxWidth = img.width + 2 * opt.margin;
@@ -76,6 +87,21 @@ module.exports = function (opt) {
       sprite.total_width = ctxWidth;
       sprite.total_height = ctxHeight;
       ctx.drawImage(sprite.img, sprite.x, sprite.y, sprite.width, sprite.height);
+    });
+    return canvas;
+  }
+
+  function createBinaryTreeCanvas () {
+    var layerInfo = layer.export();
+    var canvas = new Canvas(layerInfo.width, layerInfo.height);
+    var ctx = canvas.getContext('2d');
+    lodash.each(sprites, function (sprite, index) {
+      var layerItem = layerInfo.items[index];
+      sprite.total_width = layerInfo.width;
+      sprite.total_height = layerInfo.height;
+      sprite.x = layerItem.x;
+      sprite.y = layerItem.y;
+      ctx.drawImage(sprite.img, layerItem.x, layerItem.y, layerItem.width, layerItem.height);
     });
     return canvas;
   }
@@ -126,7 +152,7 @@ module.exports = function (opt) {
       base: opt.out,
       relative: opt.name,
       path: path.join(opt.out, opt.name),
-      canvas: createCanvas()
+      canvas: opt.orientation === 'binary-tree' ? createBinaryTreeCanvas() : createCanvas()
     };
 
     if (opt.retina) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "gaze": "^0.5.1",
     "imageinfo": "^1.0.4",
     "through2": "^0.4.1",
-    "mustache": "^0.8.1"
+    "mustache": "^0.8.1",
+    "layout": "~2.0.0"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/test/css-sprite.js
+++ b/test/css-sprite.js
@@ -247,4 +247,23 @@ describe('css-sprite (lib/css-sprite.js)', function () {
         done();
       })
   });
+  it('should return an object stream with a binary-tree sprite', function (done) {
+    vfs.src('./test/fixtures/**')
+      .pipe(sprite({
+        out: './dist/img',
+        name: 'sprites.png',
+        orientation: 'binary-tree'
+      }))
+      .pipe(through2.obj(function (file, enc, cb) {
+        var img = new Image();
+        img.src = file.contents;
+        file.path.should.equal('dist/img/sprites.png');
+        file.relative.should.equal('sprites.png');
+        img.width.should.equal(276);
+        img.height.should.equal(276);
+        cb();
+      }))
+      .on('data', noop)
+      .on('end', done);
+  });
 });


### PR DESCRIPTION
This is an attempt at allowing for a binary-tree orientation method requested in Issue #13.

This is the bare minimum for implementing this feature, however, it seems a bit silly to use two different layout methods for vertical/horizontal and binary tree. I think it would be better to use the `layout` for all of them, but that might be overstepping the bounds of this pull request. Anyway, looking for feedback before I continue.
