### PR TITLE
Change default margin from 5px to 4px as a better default for retina images

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,7 +69,7 @@ var opts = require('nomnom')
     help: 'background color of the sprite in hex'
   })
   .option('margin', {
-    default: 5,
+    default: 4,
     help: 'margin in px between tiles'
   })
   .option('opacity', {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var defaults = {
   orientation: 'vertical',
   retina: false,
   background: '#FFFFFF',
-  margin: 5,
+  margin: 4,
   opacity: 0,
 };
 

--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -16,7 +16,7 @@ var Color = require('color');
 json2css.addTemplate('sprite', require(path.join(__dirname, 'templates/sprite.js')));
 
 module.exports = function (opt) {
-  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 5, processor: 'css', cssPath: '../images', orientation: 'vertical'}, opt);
+  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 4, processor: 'css', cssPath: '../images', orientation: 'vertical'}, opt);
   opt.styleExtension = (opt.processor === 'stylus') ? 'styl' : opt.processor;
   var layoutOrientation = opt.orientation === 'vertical' ? 'top-down' : opt.orientation === 'horizontal' ? 'left-right' : 'binary-tree';
   var layer = layout(layoutOrientation);

--- a/readme.md
+++ b/readme.md
@@ -43,11 +43,11 @@ Options:
    -n, --name             name of sprite file without file extension   [sprite]
    -p, --processor        output format of the css. one of css, less, sass, scss or stylus  [css]
    -t, --template         output template file, overrides processor option
-   -r, --retina           generate both retina and standard sprites. src images have to be in retina resolution
+   -r, --retina           generate both retina and standard sprites. src images have to be in retina resolution (doubled dimensions, with even-numbered height and width)
    -s, --style            file to write css to, if omitted no css is written
    -w, --watch            continuously create sprite
    --background           background color of the sprite in hex  [#FFFFFF]
-   --margin               margin in px between tiles  [5]
+   --margin               margin in px between tiles  [4]
    --opacity              background opacity of the sprite. defaults to 0 when png or 100 when jpg  [0]
    --orientation          orientation of the sprite image (vertical|horizontal|binary-tree)  [vertical]
    --prefix               prefix for the class name used in css (without .)
@@ -71,7 +71,7 @@ sprite.create(options, cb);
 * **retina:** generate both retina and standard sprites. src images have to be in retina resolution
 * **background** background color of the sprite in hex. Defaults to #FFFFFF
 * **style:** file to write css to, if omitted no css is written
-* **margin:** margin in px between tiles  [5]
+* **margin:** margin in px between tiles.  (Use an even number if generating retina sprites).  [4]
 * **opacity** background opacity of the sprite between 0 and 100. Defaults to 0 when png or 100 when jpg
 * **orientation:** orientation of the sprite image (vertical|horizontal|binary-tree) [vertical]
 * **prefix:** prefix for the class name used in css (without .) [icon]
@@ -137,7 +137,7 @@ module.exports = function(grunt) {
         'cssPath': '../images',
         'processor': 'css',
         'orientation': 'vertical',
-        'margin': 5
+        'margin': 4
       },
       sprite: {
         options: {
@@ -194,7 +194,7 @@ Options to use `css-sprite` with [Grunt](http://gruntjs.com) are the same as for
 .icon-camera
   +sprite($camera)
 
-// cart icon (cart.png in src directory)  
+// cart icon (cart.png in src directory)
 .icon-cart
   +sprite($cart)
 ```


### PR DESCRIPTION
Addresses issue https://github.com/aslansky/css-sprite/issues/38
