### PR TITLE
=BG= allow absolute paths for `template` option

### DIFF
--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -50,7 +50,9 @@ function cssTemplate (params) {
     }
   });
   // Render and return CSS
-  var tmplFile = options.template ? fs.readFileSync(path.join(process.cwd(), options.template), 'utf8') : tmpl[options.processor];
+  var tmplFile = options.template ?
+    fs.readFileSync(path.resolve(process.cwd(), options.template), 'utf8') :
+    tmpl[options.processor];
   var css = mustache.render(tmplFile, tmplParams);
   return css;
 }


### PR DESCRIPTION
- absolute paths were previously simply getting concatenated on the end of `process.cwd()` using `path.join()`
- use `path.resolve()` instead such that both absolute and relative paths work properly