### PR TITLE
Add option to disable sorting of layout

### DIFF
--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -16,10 +16,10 @@ var Color = require('color');
 json2css.addTemplate('sprite', require(path.join(__dirname, 'templates/sprite.js')));
 
 module.exports = function (opt) {
-  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 4, processor: 'css', cssPath: '../images', orientation: 'vertical'}, opt);
+  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 4, processor: 'css', cssPath: '../images', orientation: 'vertical', sort: true}, opt);
   opt.styleExtension = (opt.processor === 'stylus') ? 'styl' : opt.processor;
   var layoutOrientation = opt.orientation === 'vertical' ? 'top-down' : opt.orientation === 'horizontal' ? 'left-right' : 'binary-tree';
-  var layer = layout(layoutOrientation);
+  var layer = layout(layoutOrientation, {'sort': opt.sort});
 
   if (opt.opacity === 0 && opt.format === 'jpg') {
     opt.opacity = 1;


### PR DESCRIPTION
Lets the user specify that the layout should not be sorted by the layout engine, but instead let the filename control the order (ideal if making a spritesheet of an animation and the user wants the order of the sprites to be consistent with the animation sequence). Defaults to true to make i backwards compatible with previous behaviour.