### PR TITLE
[retina support, fixes #42] Changed the call to lwip's resize() function to use the 'grid' interpolation method

### DIFF
--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -84,7 +84,8 @@ module.exports = function (opt) {
     var width = Math.floor(retinaCanvas.width() / 2);
     var height = Math.floor(retinaCanvas.height() / 2);
     retinaCanvas.clone(function(err, clone){
-      clone.resize(width, height, function (err, image) {
+      // tell lwip to use the 'grid' interpolation method when resizing - it makes the resized image look much better
+      clone.resize(width, height, 'grid', function (err, image) {
         cb(image);
       });
     });


### PR DESCRIPTION
makes the resized image look much better.