### PR TITLE
added option for image interpolation

### DIFF
--- a/lib/css-sprite.js
+++ b/lib/css-sprite.js
@@ -16,7 +16,7 @@ var Color = require('color');
 json2css.addTemplate('sprite', require(path.join(__dirname, 'templates/sprite.js')));
 
 module.exports = function (opt) {
-  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 4, processor: 'css', cssPath: '../images', orientation: 'vertical', sort: true}, opt);
+  opt = lodash.extend({}, {name: 'sprite', format: 'png', margin: 4, processor: 'css', cssPath: '../images', orientation: 'vertical', sort: true, interpolation: 'grid'}, opt);
   opt.styleExtension = (opt.processor === 'stylus') ? 'styl' : opt.processor;
   var layoutOrientation = opt.orientation === 'vertical' ? 'top-down' : opt.orientation === 'horizontal' ? 'left-right' : 'binary-tree';
   var layer = layout(layoutOrientation, {'sort': opt.sort});
@@ -85,7 +85,7 @@ module.exports = function (opt) {
     var height = Math.floor(retinaCanvas.height() / 2);
     retinaCanvas.clone(function(err, clone){
       // tell lwip to use the 'grid' interpolation method when resizing - it makes the resized image look much better
-      clone.resize(width, height, 'grid', function (err, image) {
+      clone.resize(width, height, opt.interpolation, function (err, image) {
         cb(image);
       });
     });

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ sprite.create(options, cb);
 * **orientation:** orientation of the sprite image (vertical|horizontal|binary-tree) [vertical]
 * **prefix:** prefix for the class name used in css (without .) [icon]
 * **sort:** enable/disable sorting of layout [true]
+* **interpolation** Interpolation algorithm used when scaling retina images to standard definition. Possible values are `nearest-neighbor`,`moving-average`,`linear`,`grid`,`cubic`,`lanczos`. Defaults to `grid`.
 
 
 ### Example

--- a/tasks/css_sprite.js
+++ b/tasks/css_sprite.js
@@ -28,7 +28,8 @@ module.exports = function(grunt) {
       prefix: 'icon',
       background: '#FFFFFF',
       sort: true,
-      opacity: 0
+      opacity: 0,
+      interpolation: 'grid'
     });
 
     var done = this.async();


### PR DESCRIPTION
The default image interpolation setting ('grid') was causing my non-retina sprites to look janky. So I added an option which takes any of the following values...

- nearest-neighbor
- moving-average
- linear
- grid
- cubic
- lanczos