### PR TITLE
make classname (without '.' prefixed) available in template

### DIFF
--- a/lib/templates/sprite.js
+++ b/lib/templates/sprite.js
@@ -38,14 +38,17 @@ function cssTemplate (params) {
   items.forEach(function saveClass (item) {
     if (item.type === 'sprite') {
       item['class'] = classFn('', '');
+      item['classname'] = item['class'].slice(1);
       tmplParams.sprite = item;
     }
     else if (item.type === 'retina') {
       item['class'] = classFn('', '');
+      item['classname'] = item['class'].slice(1);
       tmplParams.retina = item;
     }
     else {
       item['class'] = classFn(item.name, '-');
+      item['classname'] = item['class'].slice(1);
       tmplParams.items.push(item);
     }
   });

--- a/readme.md
+++ b/readme.md
@@ -248,6 +248,7 @@ To use your own [mustache](http://mustache.github.io/) template for style file c
   * **offset_x** -- x offset within the sprite
   * **offset_y** -- y offset within the sprite
   * **class** -- class name of the tile
+  * **classname** -- class name of the tile, without '.' prefixed
   * **px** -- object with pixel values instead of raw data (e.g width: '250px')
       * **x**, **y**, **offset_x**, **offset_y**, **height**, **width**, **total_height**, **total_width**
 * **sprite** -- object with information about the sprite itself
@@ -255,11 +256,13 @@ To use your own [mustache](http://mustache.github.io/) template for style file c
   * **image** -- css path to sprite or base64 encode string
   * **escaped_image** -- escaped css path to sprite or base64 encode string
   * **class** -- class name of the sprite
+  * **classname** -- class name of the sprite, without '.' prefixed
 * **retina** -- object with information about the retina sprite
   * **name** -- name of the retina sprite
   * **image** -- css path to retina sprite
   * **escaped_image** -- escaped css path to retina sprite
   * **class** -- class name of the retina sprite
+  * **classname** -- class name of the retina sprite, without '.' prefixed
   * **total_width** -- height of the retina sprite (for background-size)
   * **total_height** -- width of the retina sprite (for background-size)
   * **px** -- object with pixel values

--- a/test/css-sprite.js
+++ b/test/css-sprite.js
@@ -154,6 +154,41 @@ describe('css-sprite (lib/css-sprite.js)', function () {
         done();
       });
   });
+  it('should return a object stream with a sprite and a css file (using a custom scss template containing {{classname}})', function (done) {
+    var png, scss;
+    vfs.src('./test/fixtures/**')
+      .pipe(sprite({
+        out: './dist/img',
+        name: 'sprites',
+        processor: 'scss',
+        style: './dist/scss/sprites.scss',
+        template: './test/template/scss.mustache'
+      }))
+      .pipe(through2.obj(function (file, enc, cb) {
+        if (file.relative.indexOf('png') > -1) {
+          png = file;
+        }
+        else {
+          scss = file;
+        }
+        cb();
+      }))
+      .on('data', noop)
+      .on('end', function () {
+        png.should.be.ok;
+        png.path.should.equal(path.join('dist', 'img', 'sprites.png'));
+        png.relative.should.equal('sprites.png');
+        scss.should.be.ok;
+        scss.path.should.equal('./dist/scss/sprites.scss');
+        scss.relative.should.equal('sprites.scss');
+        scss.contents.toString('utf-8').should.containEql('%icon');
+        scss.contents.toString('utf-8').should.containEql('$icon-camera');
+        scss.contents.toString('utf-8').should.containEql('$icon-cart');
+        scss.contents.toString('utf-8').should.containEql('$icon-command');
+        scss.contents.toString('utf-8').should.containEql('$icon-font');
+        done();
+      });
+  });
   it('should return a object stream with retina sprite, normal sprite and css with media query', function (done) {
     var png = [], css;
     vfs.src('./test/fixtures/**')

--- a/test/template/scss.mustache
+++ b/test/template/scss.mustache
@@ -1,0 +1,9 @@
+{{#sprite}}
+%{{classname}} {
+  background-image: url('{{{escaped_image}}}');
+}
+{{/sprite}}
+
+{{#items}}
+${{classname}}: {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.height}};
+{{/items}}


### PR DESCRIPTION
https://github.com/aslansky/css-sprite/issues/41
